### PR TITLE
Bug #126500 : Sub form accept characters for calendar field

### DIFF
--- a/administrator/assets/js/tjfields.js
+++ b/administrator/assets/js/tjfields.js
@@ -82,11 +82,11 @@ jQuery(document).ready(function(){
         return regex.test(value);
     });
 
-	 /* It restrict the user for manual input in datepicker field */
-    jQuery('.calendar-textfield-class').focusin(function(event) {
-        event.preventDefault();
-        jQuery(this).next('button').focus().click();
-    });
+	/* It restrict the user for manual input in datepicker field */
+    jQuery(document).delegate('.calendar-textfield-class', 'focusin', function(event) {
+		event.preventDefault();
+		jQuery(this).next('button').focus().click();
+	});
 
     /* Code for number field validation */
     document.formvalidator.setHandler('check_number_field', function(value, element) {


### PR DESCRIPTION
Resolved : We have open the calendar box on focusin trigger for regular calendar field & restricts user to type in respective field same we have done for the subform calendar field also. In fact, same function is used for regular as well as subform calendar field