### PR TITLE
Feature #127485 feat: New field type - moduleposition

### DIFF
--- a/admin_language/en-GB/en-GB.com_tjfields.ini
+++ b/admin_language/en-GB/en-GB.com_tjfields.ini
@@ -215,6 +215,7 @@ COM_TJFIELDS_YES="Yes"
 COMTJFILEDS_FIELD_CREATED_SUCCESSFULLY="Field saved successfully"
 COMTJFILEDS_GROUP_CREATED_SUCCESSFULLY="Group saved successfully"
 COM_TJFIELDS_NUMBER="Number"
+COM_TJFIELDS_MODULEPOSITION="Module Position"
 
 ; Since 1.1 - Aug 2014
 ; Countries list

--- a/administrator/models/fields/tjfieldfields.php
+++ b/administrator/models/fields/tjfieldfields.php
@@ -70,6 +70,7 @@ class JFormFieldtjfieldfields extends JFormField
 		$options[] = JHtml::_('select.option', 'file', JText::_('COM_TJFIELDS_FILE'));
 		$options[] = JHtml::_('select.option', 'spacer', JText::_('COM_TJFIELDS_SPACER'));
 		$options[] = JHtml::_('select.option', 'subform', JText::_('COM_TJFIELDS_SUBFORM'));
+		$options[] = JHtml::_('select.option', 'moduleposition', JText::_('COM_TJFIELDS_MODULEPOSITION'));
 
 		if ($installUcm === 1)
 		{

--- a/administrator/models/forms/field.xml
+++ b/administrator/models/forms/field.xml
@@ -66,6 +66,7 @@
 				<option value="subform">COM_TJFIELDS_SUBFORM</option>
 				<option value="ucmsubform">COM_TJFIELDS_UCMSUBFORM</option>
 				<option value="number">COM_TJFIELDS_NUMBER</option>
+				<option value="moduleposition">COM_TJFIELDS_MODULEPOSITION</option>
 		</field>
 
 		<field name="required"

--- a/administrator/models/forms/types/forms/moduleposition.xml
+++ b/administrator/models/forms/types/forms/moduleposition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="position" type="moduleposition" description="COM_MODULES_FIELD_POSITION_DESC"
+		label="COM_MODULES_FIELD_POSITION_LABEL" default="" maxlength="50">
+		<fieldset name="params">
+			<field name="addfieldpath" type="hidden" default="/administrator/components/com_modules/models/fields"/>
+		</fieldset>
+	</fields>
+</form>


### PR DESCRIPTION
Added a new field type moduleposition (supported by joomla).

Provides a text input and button to set the position of a module:
-type (mandatory) must be moduleposition.
-name (mandatory) is the unique name of the field.
-label (mandatory) (translatable) is the descriptive title of the field.
-description (optional) (translatable) is text that will be shown as a tooltip when the user moves the mouse over the drop-down box.