### PR TITLE
Bug #129214 fix: date field accepting character by right click with mouse and copy paste

### DIFF
--- a/administrator/assets/js/tjfields.js
+++ b/administrator/assets/js/tjfields.js
@@ -121,7 +121,7 @@ jQuery(document).ready(function(){
        jQuery(this).parent().siblings(':eq(0)').show();
     });
 
-    jQuery(document).delegate('.calendar-textfield-class', 'keydown', function(event) {
+    jQuery(document).delegate('.calendar-textfield-class', 'keydown contextmenu', function(event) {
 			return false;
     });
 


### PR DESCRIPTION
Issue: date field accepting character by right click with mouse and copy paste.