### PR TITLE
Task #144091 feat: Add cluster and user fields to make UCM cluster aw…

### DIFF
--- a/admin_language/en-GB/en-GB.com_tjfields.ini
+++ b/admin_language/en-GB/en-GB.com_tjfields.ini
@@ -462,3 +462,9 @@ COM_TJFIELDS_NORMAL="Normal"
 
 ; Item Category
 COM_TJFIELDS_ITEM_CATEGORY="Item Category"
+
+;Ownership
+COM_TJFIELDS_OWNERSHIP="Ownership"
+
+;cluster
+COM_TJFIELDS_CLUSTER="cluster"

--- a/administrator/assets/js/ownershipfield.js
+++ b/administrator/assets/js/ownershipfield.js
@@ -1,0 +1,74 @@
+/*
+ * @package    Com_Tjfields
+ * @author     Techjoomla <extensions@techjoomla.com>
+ * @copyright  Copyright (c) 2009-2019 TechJoomla. All rights reserved
+ * @license    GNU General Public License version 2, or later
+ */
+
+var ownership = {
+	/* This function to get all users in tjucm via ajax */
+	getUsers: function (element) {
+		jQuery('.user-ownership, .chzn-results').empty();
+		jQuery.ajax({
+			url: Joomla.getOptions('system.paths').base + "/index.php?option=com_cluster&task=clusterusers.getUsersByClientId&format=json",
+			type: 'POST',
+			data: element,
+			dataType:"json",
+			success: function (data) {
+				for(index = 0; index < data.length; ++index)
+				{
+					var op="<option value='"+data[index].value+"' > " + data[index]['text'] + "</option>" ;
+					jQuery('.user-ownership').append(op);
+				}
+
+				/* IMP : to update to chz-done selects*/
+				jQuery(".user-ownership").trigger("liszt:updated");
+			}
+		});
+	},
+	/* This function to populate all users in ownership field of tjucm form */
+	setUsers: function (element) {
+		if (jQuery(".cluster-ownership")[0])
+		{
+			let clientId = jQuery(".cluster-ownership").val();
+
+			element.client = clientId;
+			element.iscluster = 1;
+
+			if (jQuery.trim(clientId) != '' && clientId != 'undefined' )
+			{
+				this.getUsers(element);
+			}
+		}
+		else
+		{
+			this.getUsers(element);
+		}
+	}
+}
+
+jQuery(document).ready(function() {
+
+	if (jQuery(".user-ownership")[0])
+	{
+		let dataFields = {client: 0, iscluster: 0};
+
+		//Get All users for user field
+		ownership.setUsers(dataFields);
+	}
+
+	/* This function to get users based on cluster value in tjucm via ajax */
+	jQuery('.cluster-ownership').change(function(){
+
+		// Check class exists or not
+		if (!jQuery(".user-ownership")[0]){
+			return false;
+		}
+
+		let clientId = jQuery(this).val();
+		let dataFields = {client: clientId,iscluster: 1};
+
+		//Get All associated users
+		ownership.getUsers(dataFields);
+	});
+});

--- a/administrator/models/field.php
+++ b/administrator/models/field.php
@@ -188,7 +188,7 @@ class TjfieldsModelField extends JModelAdmin
 		$validatedData = $this->validate($form, $data);
 
 		// Sanitize the field data
-		foreach($validatedData as $k => $validatedFieldData)
+		foreach ($validatedData as $k => $validatedFieldData)
 		{
 			if (!is_array($validatedFieldData))
 			{
@@ -283,6 +283,19 @@ class TjfieldsModelField extends JModelAdmin
 			$client = explode('.', $data['client']);
 			$client = $client[0];
 			$data_unique_name = $client . '_' . $data['client_type'] . '_' . $data_name;
+
+			// To store cluster type fields in core UCM hence rename the field name
+			if ($data['type'] == 'cluster')
+			{
+				$data_unique_name = $client . '_' . $data['type'] . 'clusterid';
+			}
+
+			// To store ownership type fields in core UCM hence rename the field name
+			if ($data['type'] == 'ownership')
+			{
+				$data_unique_name = $client . '_' . $data['type'] . 'createdby';
+			}
+
 			$data['name'] = $data_unique_name;
 		}
 

--- a/administrator/models/fields/cluster.php
+++ b/administrator/models/fields/cluster.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package    Tjfields
+ * @author     Techjoomla <extensions@techjoomla.com>
+ * @copyright  Copyright (c) 2009-2019 TechJoomla. All rights reserved.
+ * @license    GNU General Public License version 2 or later.
+ */
+
+defined('JPATH_BASE') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+JFormHelper::loadFieldClass('list');
+
+/**
+ * Supports an HTML select list of allocated cluster
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+
+class JFormFieldCluster extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'cluster';
+
+	/**
+	 * Fiedd to decide if options are being loaded externally and from xml
+	 *
+	 * @var		integer
+	 * @since	__DEPLOY_VERSION__
+	 */
+	protected $loadExternally = 0;
+
+	/**
+	 * Method to get a list of options for cluster field.
+	 *
+	 * @return array An array of JHtml options.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getOptions()
+	{
+		$user = Factory::getUser();
+
+		if (!$user->id)
+		{
+			return $options;
+		}
+
+		$superUser    = $user->authorise('core.admin');
+		$options = $clusters = array();
+
+		// Initialize array to store dropdown options
+		$options[] = HTMLHelper::_('select.option', "", Text::_('COM_TJFIELDS_OWNERSHIP_CLUSTER'));
+
+		$data = $this->getLayoutData();
+
+		$fieldName = str_replace("[", '_', $data['field']->name);
+		$fieldName = str_replace("]", '', $fieldName);
+
+		// Get com_subusers component status
+		$clusterExist = ComponentHelper::getComponent('com_cluster', true)->enabled;
+
+		if (!$clusterExist)
+		{
+			return $options;
+		}
+
+		JLoader::import("/components/com_cluster/includes/cluster", JPATH_ADMINISTRATOR);
+		$ClusterModel = ClusterFactory::model('ClusterUsers');
+		$ClusterModel->setState('filter.group_by_client_id', 1);
+
+		if (!$superUser)
+		{
+			$ClusterModel->setState('filter.user_id', $user->id);
+		}
+
+		// Get all assigned cluster entries
+		$clusters = $ClusterModel->getItems();
+
+		// Get com_subusers component status
+		$subUserExist = ComponentHelper::getComponent('com_subusers', true)->enabled;
+
+		if ($subUserExist)
+		{
+			JLoader::import("/components/com_subusers/includes/rbacl", JPATH_ADMINISTRATOR);
+		}
+
+		if (!empty($clusters))
+		{
+			foreach ($clusters as $cluster)
+			{
+				// Check rbacl component active and normal user is logged-in
+				if ($subUserExist && !$superUser)
+				{
+					// Check user has permission for mentioned cluster
+					if (RBACL::authorise($user->id, 'com_multiagency', 'core.adduser', $cluster->client_id))
+					{
+						$options[] = HTMLHelper::_('select.option', $cluster->client_id, trim($cluster->name));
+					}
+				}
+				else
+				{
+					$options[] = HTMLHelper::_('select.option', $cluster->client_id, trim($cluster->name));
+				}
+			}
+		}
+
+		return $options;
+	}
+}

--- a/administrator/models/fields/ownership.php
+++ b/administrator/models/fields/ownership.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package    Tjfields
+ * @author     Techjoomla <extensions@techjoomla.com>
+ * @copyright  Copyright (c) 2009-2019 TechJoomla. All rights reserved.
+ * @license    GNU General Public License version 2 or later.
+ */
+
+defined('JPATH_BASE') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+JFormHelper::loadFieldClass('list');
+
+/**
+ * Supports an HTML select list of allocated cluster
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+
+class JFormFieldOwnerShip extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'ownership';
+
+	/**
+	 * Method to get a list of options for cluster field.
+	 *
+	 * @return array An array of JHtml options.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getOptions()
+	{
+		$user = Factory::getUser();
+
+		if (!$user->id)
+		{
+			return $options;
+		}
+
+		$doc = Factory::getDocument();
+		$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/ownershipfield.js');
+
+		$options = array();
+
+		// Initialize array to store dropdown options
+		$options[] = HTMLHelper::_('select.option', "", Text::_('COM_TJFIELDS_OWNERSHIP_USER'));
+
+		return $options;
+	}
+}

--- a/site_language/en-GB/en-GB.com_tjfields.ini
+++ b/site_language/en-GB/en-GB.com_tjfields.ini
@@ -28,3 +28,9 @@ COM_TJFIELDS_FILE_DELETE_SUCCESS="File deleted successfully."
 COM_TJFIELDS_FILE_DELETE_ERROR="Error deleting file. please try again after some time."
 COM_TJFIELDS_FILE_DELETE_CONFIRM="Are you sure you want to delete this file?"
 COM_TJFIELDS_FILE_NOT_FOUND="File not found."
+
+;ownership field
+COM_TJFIELDS_OWNERSHIP_USER ="Select User"
+
+;cluster field
+COM_TJFIELDS_OWNERSHIP_CLUSTER ="Select Cluster"


### PR DESCRIPTION
1 - Create two field types 'cluster' and 'ownership'.
2 - create fields by using above field types with class names 'cluster-ownership' & 'user-ownership' respectively.
3 - If cluster and user field is available on 'UCM form' then we will show 'cluster' field with all clusters of logged-in users and 'user' field without value.
4 - Based on the chosen cluster from dropdown we will display associated users.
5 - If cluster field is not available in 'UCM form' then we will display all Joomla users in the 'user' field.
6 - If cluster field is available in UCM post data we will apply validation
