### PR TITLE
Bug #170576 fix: Fatal error: Cannot declare class JFormFieldFile

### DIFF
--- a/administrator/models/fields/tjfile.php
+++ b/administrator/models/fields/tjfile.php
@@ -20,7 +20,7 @@ use Joomla\CMS\HTML\HTMLHelper;
  * @link   http://www.w3.org/TR/html-markup/input.file.html#input.file
  * @since  11.1
  */
-class JFormFieldFile extends JFormField
+class JFormFieldTjFile extends JFormField
 {
 	/**
 	 * The form field type.

--- a/administrator/models/fields/tjsql.php
+++ b/administrator/models/fields/tjsql.php
@@ -16,7 +16,7 @@ JFormHelper::loadFieldClass('list');
  *
  * @since  1.7.0
  */
-class JFormFieldSQL extends JFormFieldList
+class JFormFieldTjSQL extends JFormFieldList
 {
 	/**
 	 * The form field type.


### PR DESCRIPTION
Bug #170576 fix: Fatal error: Cannot declare class JFormFieldFile, because the name is already in use in /home/treest/public_html/administrator/components/com_tjfields/models/fields/file.php on line 23