### PR TITLE
Task#171555 fix: Php8 compatibility issue

### DIFF
--- a/administrator/controllers/groups.php
+++ b/administrator/controllers/groups.php
@@ -22,7 +22,7 @@ class TjfieldsControllerGroups extends JControllerAdmin
 	 * Proxy for getModel.
 	 * @since	1.6
 	 */
-	public function getModel($name = 'group', $prefix = 'TjfieldsModel')
+	public function getModel($name = 'group', $prefix = 'TjfieldsModel', $config = array('ignore_request' => true))
 	{
 		$model = parent::getModel($name, $prefix, array('ignore_request' => true));
 		return $model;


### PR DESCRIPTION
Fatal error: Declaration of TjfieldsControllerGroups::getModel($name = 'group', $prefix = 'TjfieldsMo...') must be compatible with Joomla\CMS\MVC\Controller\BaseController::getModel($name = '', $prefix = '', $config = []) in /var/www/ttpllt-php8.local/public/q2c/administrator/components/com_tjfields/controllers/groups.php on line 25