### PR TITLE
Task #00000 chore : Increase Database Column Length for Feedback Field to Prevent Save Failures

### DIFF
--- a/administrator/sql/install.mysql.utf8.sql
+++ b/administrator/sql/install.mysql.utf8.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS `#__tjfields_fields_value` (
 	`id` int(11) NOT NULL AUTO_INCREMENT,
 	`field_id` int(11) NOT NULL COMMENT 'Field table ID' DEFAULT 0,
 	`content_id` int(11) NOT NULL COMMENT 'client specific id' DEFAULT 0,
-	`value` text DEFAULT NULL,
+	`value` longtext DEFAULT NULL,
 	`option_id` int(11) NOT NULL DEFAULT 0,
 	`user_id` int(11) NOT NULL DEFAULT 0,
 	`email_id` varchar(255) NOT NULL DEFAULT '',


### PR DESCRIPTION
IN the DPE project there is one DPO Feedback field now saves reliably after updating the database column to LONGTEXT. Users can enter and save small, medium, and large multi-paragraph text without truncation or errors. Both autosave and manual save work consistently, with no silent failures and no log errors. QA has verified that copy-pasted long content and regular input are saved correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased storage capacity for field values to support larger content storage in the database.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->